### PR TITLE
Astro Images MVC Setup, Can be Added without Login (for now)

### DIFF
--- a/app/controllers/astro_images_controller.rb
+++ b/app/controllers/astro_images_controller.rb
@@ -1,0 +1,25 @@
+class AstroImagesController < ApplicationController
+
+  def new
+    @astro_image = AstroImage.new
+  end
+
+  def create
+    @astro_image = AstroImage.new(astro_image_params)
+    if @astro_image.save
+      redirect_to astro_images_path, notice: 'Image uploaded successfully!'
+    else
+      render :new
+    end
+  end
+
+  def index
+    @astro_images = AstroImage.all
+  end
+
+  private
+
+  def astro_image_params
+    params.require(:astro_image).permit(:title, :description, :image)
+  end
+end

--- a/app/helpers/astro_images_helper.rb
+++ b/app/helpers/astro_images_helper.rb
@@ -1,0 +1,2 @@
+module AstroImagesHelper
+end

--- a/app/models/astro_image.rb
+++ b/app/models/astro_image.rb
@@ -1,0 +1,3 @@
+class AstroImage < ApplicationRecord
+  has_one_attached :image
+end

--- a/app/views/astro_images/index.html.erb
+++ b/app/views/astro_images/index.html.erb
@@ -1,0 +1,10 @@
+<p><%= link_to 'Upload New Astro Image', new_astro_image_path %></p>
+
+<p>Images of Astrology from our Users</p>
+<% @astro_images.each do |image| %>
+  <div class="astro-image">
+    <%= image_tag image.image, alt: image.title %>
+    <p><strong><%= image.title %></strong></p>
+    <p><%= image.description %></p>
+  </div>
+<% end %>

--- a/app/views/astro_images/new.html.erb
+++ b/app/views/astro_images/new.html.erb
@@ -1,0 +1,12 @@
+<%= simple_form_for @astro_image do |f| %>
+  <%= f.label :title %>
+  <%= f.text_field :title %>
+
+  <%= f.label :description %>
+  <%= f.text_area :description %>
+
+  <%= f.label :image %>
+  <%= f.file_field :image %>
+
+  <%= f.submit 'Upload Image' %>
+<% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -26,6 +26,9 @@
         <li>
           <a href="#" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Contact</a>
         </li>
+        <li>
+          <a href="#" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent"><%= link_to 'Astronomy Images', astro_images_path %></a>
+        </li>
       </ul>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,11 @@ Rails.application.routes.draw do
 
   get '/about', to: 'nebulae#about'
 
-  
+
   resources :supernovae
 
   get '/supernovae', to: 'supernovae#index', as: :supernovae_index
+
+
+  resources :astro_images, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20240425191951_create_astro_images.rb
+++ b/db/migrate/20240425191951_create_astro_images.rb
@@ -1,0 +1,11 @@
+class CreateAstroImages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :astro_images do |t|
+      t.string :title
+      t.text :description
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_24_201421) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_25_191951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,6 +66,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_24_201421) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "astro_images", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "galaxies", force: :cascade do |t|

--- a/test/controllers/astro_images_controller_test.rb
+++ b/test/controllers/astro_images_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AstroImagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/astro_images.yml
+++ b/test/fixtures/astro_images.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  description: MyText
+  image: MyString
+
+two:
+  title: MyString
+  description: MyText
+  image: MyString

--- a/test/models/astro_image_test.rb
+++ b/test/models/astro_image_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AstroImageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Looking to add user input/their ability to add to the application. Adding astrology images seems to be a suitable and relevant to the project approach to this.

An astro_image model was initially created with an image required, form view built around this to require a name, description and image attached from the user's local system to submit to the astrology images records.

Added a link to the Navbar partial so users can access initially the Nebula index, then click the link to access the new astrology image form page.

Limited in the routes for resources for the astro_images to only contain the actions of index, show, new and create as they are the only ones needed at this point, as this is not an overly complex MVC architecture for the application. The controller actions only contain new, create and index along with a private method for deciding the controller parameters.

Adding the images does not require login, something that will likely be configured later linked to Devise expansion in the application.