### PR TITLE
Standard CSS Added for Astro Images in new CSS File

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 # For application jobs
 gem "solid_queue"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,9 @@ GEM
       activesupport (>= 5.2)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -199,6 +202,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.22.3)
     msgpack (1.7.2)
@@ -297,6 +301,8 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    ruby-vips (2.2.1)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -387,6 +393,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   faker
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/assets/stylesheets/astro_images.css
+++ b/app/assets/stylesheets/astro_images.css
@@ -1,0 +1,26 @@
+.astro-image {
+  border: 1px solid #ddd;
+  padding: 10px;
+  margin-bottom: 20px;
+}
+
+.astro-image img {
+  max-width: 100%;
+  height: auto;
+}
+
+.astro-image p {
+  font-size: 14px;
+  color: #333;
+}
+
+.astro-images-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.astro-image:hover {
+  border-color: #0074d9;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/app/views/astro_images/index.html.erb
+++ b/app/views/astro_images/index.html.erb
@@ -3,7 +3,7 @@
 <p>Images of Astrology from our Users</p>
 <% @astro_images.each do |image| %>
   <div class="astro-image">
-    <%= image_tag image.image, alt: image.title %>
+    <%= image_tag image.image, alt: image.title, loading: "lazy" %>
     <p><strong><%= image.title %></strong></p>
     <p><%= image.description %></p>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
   <%= csp_meta_tag %>
   <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+  <%= stylesheet_link_tag 'astro_images', media: 'all' %>
   <%= javascript_importmap_tags %>
   <%= content_for :head %>
 </head>


### PR DESCRIPTION
Added a new astro_images CSS file that is called within the application.html.erb view file to provide custom styling to the astro_images index and also the new astro_images creation form page. These include incorporating a grid system, p text styling and hover over a record styling properties.

Lazy loading has been added to the index view for when there is a large amount of media/images to load on the page, so it loads according to the user's page scrolling stage.

Also uncommented and installed the Image Processing gem for making variants to Active Storage added images in the future.