### PR TITLE
Added a Description Character Limit, Message in the View Also

### DIFF
--- a/app/models/astro_image.rb
+++ b/app/models/astro_image.rb
@@ -1,3 +1,6 @@
 class AstroImage < ApplicationRecord
   has_one_attached :image
+  validates :title, presence: true
+  validates :description, length: { maximum: 200,
+    too_long: "%{count} characters is the maximum allowed" }
 end

--- a/app/views/astro_images/new.html.erb
+++ b/app/views/astro_images/new.html.erb
@@ -4,6 +4,9 @@
 
   <%= f.label :description %>
   <%= f.text_area :description %>
+  <% if @astro_image.errors[:description].any? %>
+    <p class="error-message"><%= @astro_image.errors.full_messages_for(:description).first %></p>
+  <% end %>
 
   <%= f.label :image %>
   <%= f.file_field :image %>


### PR DESCRIPTION
For the astro_image model and the astro_image form:

Added a description character limit of 200 characters, if over 200 then the user will get a message thatr "200 is the maxmimum allowed".

Also added a title validation rule to enforce a title being entered before producing an astro_image record in the astro_image model