### PR TITLE
Added Astro Images Show Page and Links to the First Blob

### DIFF
--- a/app/controllers/astro_images_controller.rb
+++ b/app/controllers/astro_images_controller.rb
@@ -17,6 +17,10 @@ class AstroImagesController < ApplicationController
     @astro_images = AstroImage.all
   end
 
+  def show
+    @astro_image = AstroImage.find(1)
+  end
+
   private
 
   def astro_image_params

--- a/app/views/astro_images/index.html.erb
+++ b/app/views/astro_images/index.html.erb
@@ -3,8 +3,10 @@
 <p>Images of Astrology from our Users</p>
 <% @astro_images.each do |image| %>
   <div class="astro-image">
-    <%= image_tag image.image, alt: image.title, loading: "lazy" %>
-    <p><strong><%= image.title %></strong></p>
-    <p><%= image.description %></p>
+    <%= link_to astro_image_path(image.image) do %>
+      <%= image_tag image.image, alt: image.title, loading: "lazy" %>
+      <p><strong><%= image.title %></strong></p>
+      <p><%= image.description %></p>
   </div>
+  <% end %>
 <% end %>

--- a/app/views/astro_images/show.html.erb
+++ b/app/views/astro_images/show.html.erb
@@ -1,0 +1,5 @@
+<div class="astro-image">
+    <%= image_tag @astro_image.image, alt: @astro_image.title %>
+    <p><strong><%= @astro_image.title %></strong></p>
+    <p><%= @astro_image.description %></p>
+  </div>


### PR DESCRIPTION
Added show action to the astro_images controller.

Added a new astro_images show page and link to via the entirety of the blob record for each index astro_images image.

Show page features same information and image as that of an image in the astro_images index view page.