### PR TITLE
Timezone gem implemented into the application (latest gem version)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,9 @@ gem "sassc-rails"
 # Calendar gem implementation
 gem "simple_calendar"
 
+# Accurate current and history timezones for Ruby.
+gem 'timezone', '~> 1.0'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,7 @@ GEM
     nokogiri (1.16.3-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    ostruct (0.6.0)
     pg (1.5.6)
     phlex (1.10.1)
     phlex-rails (1.1.1)
@@ -354,6 +355,8 @@ GEM
     thor (1.3.1)
     tilt (2.3.0)
     timeout (0.4.1)
+    timezone (1.3.26)
+      ostruct (~> 0.6)
     turbo-rails (2.0.5)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -411,6 +414,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   tailwindcss-rails
+  timezone (~> 1.0)
   turbo-rails
   tzinfo-data
   web-console


### PR DESCRIPTION
A search of Timezone.name on the Rails console now contains a vast amount of timezones that can be called as objects