### PR TITLE
AnyCable Setup and Redis Gem Updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@
 
 # Ignore Yarn errors as unnecessary to upload to the GitHub repository
 yarn-error.log
+bin/dist

--- a/Gemfile
+++ b/Gemfile
@@ -29,9 +29,6 @@ gem "tailwindcss-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
-# Use Redis adapter to run Action Cable in production
-gem "redis", ">= 4.0.1"
-
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 
@@ -78,6 +75,12 @@ gem "simple_calendar"
 
 # Accurate current and history timezones for Ruby.
 gem 'timezone', '~> 1.0'
+
+# For broadcasting and streaming
+gem "anycable-rails", "~> 1.5"
+
+# For compatability with AnyCable
+gem 'redis', '~> 5.2'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,21 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    anycable (1.5.0)
+      anycable-core (= 1.5.0)
+      grpc (~> 1.53)
+    anycable-core (1.5.0)
+      anyway_config (~> 2.2)
+      google-protobuf (~> 3.25)
+    anycable-rails (1.5.1)
+      anycable (~> 1.5.0)
+      anycable-rails-core (= 1.5.1)
+    anycable-rails-core (1.5.1)
+      actioncable (>= 6.0)
+      anycable-core (~> 1.5.0)
+      globalid
+    anyway_config (2.6.4)
+      ruby-next-core (~> 1.0)
     arbre (1.7.0)
       activesupport (>= 3.0.0)
       ruby2_keywords (>= 0.0.2)
@@ -152,6 +167,32 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (3.25.3)
+    google-protobuf (3.25.3-aarch64-linux)
+    google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86-linux)
+    google-protobuf (3.25.3-x86_64-darwin)
+    google-protobuf (3.25.3-x86_64-linux)
+    googleapis-common-protos-types (1.14.0)
+      google-protobuf (~> 3.18)
+    grpc (1.63.0)
+      google-protobuf (~> 3.25)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.63.0-aarch64-linux)
+      google-protobuf (~> 3.25)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.63.0-arm64-darwin)
+      google-protobuf (~> 3.25)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.63.0-x86-linux)
+      google-protobuf (~> 3.25)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.63.0-x86_64-darwin)
+      google-protobuf (~> 3.25)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.63.0-x86_64-linux)
+      google-protobuf (~> 3.25)
+      googleapis-common-protos-types (~> 1.0)
     has_scope (0.8.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -291,9 +332,9 @@ GEM
       i18n
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
-    redis (5.1.0)
-      redis-client (>= 0.17.0)
-    redis-client (0.21.1)
+    redis (5.2.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.1)
       connection_pool
     regexp_parser (2.9.0)
     reline (0.5.0)
@@ -302,6 +343,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    ruby-next-core (1.0.3)
     ruby-vips (2.2.1)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
@@ -390,6 +432,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin
+  anycable-rails (~> 1.5)
   bootsnap
   bundler-audit
   capybara
@@ -405,7 +448,7 @@ DEPENDENCIES
   phlex-rails
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
-  redis (>= 4.0.1)
+  redis (~> 5.2)
   sassc-rails
   selenium-webdriver
   simple_calendar

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,5 @@
 web: bin/rails server
 css: bin/rails tailwindcss:watch
+rpc: bundle exec anycable
+ws: bin/anycable-go --port=8080
+anycable: bundle exec anycable

--- a/bin/anycable-go
+++ b/bin/anycable-go
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd $(dirname $0)/..
+
+# It's recommended to use the exact version of AnyCable here
+version="latest"
+
+if [ ! -f ./bin/dist/anycable-go ]; then
+  echo "AnyCable server is not installed, downloading..."
+  ./bin/rails g anycable:download --version=$version --bin-path=./bin/dist
+fi
+
+curVersion=$(./bin/dist/anycable-go -v)
+
+if [[ "$version" != "latest" ]]; then
+  if [[ "$curVersion" != "$version"* ]]; then
+    echo "AnyCable server version is not $version, downloading a new one..."
+    ./bin/rails g anycable:download --version=$version --bin-path=./bin/dist
+  fi
+fi
+
+./bin/dist/anycable-go $@

--- a/config/anycable.yml
+++ b/config/anycable.yml
@@ -1,0 +1,40 @@
+# This file contains per-environment settings for AnyCable.
+#
+# Since AnyCable config is based on anyway_config (https://github.com/palkan/anyway_config), all AnyCable settings
+# can be set or overridden through the corresponding environment variables.
+# E.g., `rpc_host` is overridden by ANYCABLE_RPC_HOST, `debug` by ANYCABLE_DEBUG etc.
+#
+# Note that AnyCable recognizes REDIS_URL env variable for Redis pub/sub adapter. If you want to
+# use another Redis instance for AnyCable, provide ANYCABLE_REDIS_URL variable.
+#
+# Read more about AnyCable configuration here: https://docs.anycable.io/ruby/configuration
+#
+default: &default
+  # Turn on/off access logs ("Started..." and "Finished...")
+  access_logs_disabled: false
+  # Whether to enable gRPC level logging or not
+  log_grpc: false
+  # Use Redis to broadcast messages to AnyCable server
+  broadcast_adapter: redis
+  # You can use REDIS_URL env var to configure Redis URL.
+  # Localhost is used by default.
+  # redis_url: "redis://localhost:6379/1"
+  # Use the same channel name for WebSocket server, e.g.:
+  #   $ anycable-go --redis_channel="__anycable__"
+  # redis_channel: "__anycable__"
+
+development:
+  <<: *default
+  # WebSocket endpoint of your AnyCable server for clients to connect to
+  # Make sure you have the `action_cable_meta_tag` in your HTML layout
+  # to propogate this value to the client app
+  broadcast_adapter: http
+  websocket_url: "ws://localhost:8080/cable"
+  embedded: true
+
+test:
+  <<: *default
+
+production:
+  <<: *default
+  websocket_url: ~

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,11 +1,11 @@
 development:
-  adapter: redis
+  adapter: any_cable
   url: redis://localhost:6379/1
 
 test:
   adapter: test
 
 production:
-  adapter: redis
+  adapter: <%= ENV.fetch("ACTION_CABLE_ADAPTER", "any_cable") %>
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: nebula_rails_production

--- a/config/initializers/anycable.rb
+++ b/config/initializers/anycable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Add Warden middleware to AnyCable stack to allow accessing
+# Devise current user via `env["warden"].user`.
+#
+# See https://docs.anycable.io/ruby/authentication
+#
+# NOTE: This is only needed in environments where you use AnyCable.
+if defined?(AnyCable::Rails)
+  AnyCable::Rails::Rack.middleware.use Warden::Manager do |config|
+    Devise.warden_config = config
+  end
+end


### PR DESCRIPTION
Skipping Action Cable installation and moving straight to AnyCable, to test the capability of it.

Setting up AnyCable with gpc rather than http setup as per the install files.

Configured the Procfile.dev to handle AnyCable broadcasting via gpc.

Updated Redis gem from 5.1.0 to 5.2.0 in conjunction with ensuring compatability for AnyCable.

Ran the rails "turbo:install:redis" to ensure a smooth transition of Turbo into AnyCable.

config/cable.yml generated and updated with AnyCable specifications.